### PR TITLE
Add support for GNU Octave 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ data_background_small2.mat
 To compare with the one-shot classification results in our paper, run 'demo_classification.m' in the 'one-shot-classification' folder to demo a baseline model using Modified Hausdorff Distance.
 
 
+### GNU OCTAVE 4.0
+
+Changes needed to make MATLAB demos compatible with GNU Octave 4.0:
+
+##### Before running 'demo.m'.:
+
+ 1. Change classdef Dataset superclass to 'handle'
+    - Edit 1st line of 'Dataset.m’, and change 'matlab.mixin.copyable' to 'handle'
+    - (see http://www.mathworks.com/help/matlab/ref/matlab.mixin.copyable-class.html)
+    - CAUTION: Is this change safe? Does it degrade performance? Will it result in too much memory usage?
+
+ 2. Move 'randint' function from Dataset.m to a standalone file
+    - cut the 'randint' function from bottom of Dataset.m
+    - paste the cut function into new file randint.m
+
+
+##### Before running 'demo_classification.m' in the 'one-shot-classification' folder:
+
+ 1. Download packages:
+    - http://octave.sourceforge.net/io/index.html
+    - http://octave.sourceforge.net/statistics/index.html
+
+ 2. install/load from the Octave prompt:
+    - pkg install {download-directory}\io-2.4.1.tar.gz    - pkg install {download-directory}\statistics-1.2.4.tar.gz
+    - pkg load statistics
+
+##### Octave Bug:
+    - 'plot_motor_on_image' renders unwanted artifacts
+    - Workaround: switch to 'plot_image_only' in demo.m
+
+
 ### PYTHON
 
 Python 2.7.*   

--- a/matlab/Dataset.m
+++ b/matlab/Dataset.m
@@ -1,4 +1,4 @@
-classdef Dataset < matlab.mixin.Copyable
+classdef Dataset < handle
     %DATASET Class that stores structured character data
     %   This class stores, and provides easy access, to the
     %   sturctured character data. Using the "get" method,

--- a/matlab/Dataset.m
+++ b/matlab/Dataset.m
@@ -202,19 +202,3 @@ classdef Dataset < matlab.mixin.Copyable
     end
     
 end
-
-% Generate a matrix of uniformly distributed random integers.
-%
-% This replaces the deprecated matlab function by the same name.
-%
-% Input
-%   m: number of rows
-%   n: number of columns
-%   rg: [1 x 2] uses numbers from [min max] inclusive
-%
-% Output
-%   out: [m x n] matrix of random integers
-function out = randint(m,n,rg)
-    assert(numel(rg)==2);
-    out = randi(rg,m,n);
-end

--- a/matlab/randint.m
+++ b/matlab/randint.m
@@ -1,0 +1,15 @@
+% Generate a matrix of uniformly distributed random integers.
+%
+% This replaces the deprecated matlab function by the same name.
+%
+% Input
+%   m: number of rows
+%   n: number of columns
+%   rg: [1 x 2] uses numbers from [min max] inclusive
+%
+% Output
+%   out: [m x n] matrix of random integers
+function out = randint(m,n,rg)
+    assert(numel(rg)==2);
+    out = randi(rg,m,n);
+end


### PR DESCRIPTION
#### Summary
1. Readme.md: Added configuration and code change instructions to run Matlab demo code in GNU Octave 4.0.
2. Dataset.m and randin.m: code changes for GNU Octave 4.0 (described in Readme.md)
#### Notes
- All changes were tested on GNU Octave 4.0 on Windows 10.
- The latest binary distribution for MAC OS (GNU Octave 3.8.2) does not support classdef. To make the code work in this environment, change Dataset.m to a struct. I.e. remove the classdef statement, remove the properties section, and move each one of the methods into a separate file.
- I don't have a Matlab environment needed to test the Dataset.m superclass change ('matlab.mixin.copyable' -> 'handle'). I.e., I couldn't verify whether this change actually works in Matlab, or see if it degrades performance, results in too much memory usage, or has other negative side effects.
- The Readme.md instaructions are probably sufficient if you decide not to accept the code changes.
- If you accept the code chnages, then you may remove the redundant instructions from Readme.md.
